### PR TITLE
`--chroma-distortion-taper` and `--skip-taper`

### DIFF
--- a/Docs/Parameters.md
+++ b/Docs/Parameters.md
@@ -87,6 +87,8 @@ For more information on valid values for specific keys, refer to the [EbEncSetti
 | **TemporalFilteringStrength**    |  --tf-strength              | [0-4]                          | 1           | Manually adjust temporal filtering strength. Higher values = stronger temporal filtering                      |
 | **KeyframeTemporalFilteringStrength** |  --kf-tf-strength      | [0-4]                          | 1           | Manually adjust temporal filtering strength for keyframes. Higher values = stronger temporal filtering        |
 | **NoiseNormStrength**            |  --noise-norm-strength      | [0-4]                          | 1           | Selectively boost AC coefficients to improve fine detail retention in certain circumstances                   |
+| **ChromaDistortionTaper**        |  --chroma-distortion-taper  | [0-1]                          | 0           | Limit the chroma distortion prediction from dropping too low in full mode decision             |
+| **SkipTaper**                    |  --skip-taper               | [0-1]                          | 0           | Completely disable skip mode and skip (as defined in section 6.10.10 and 6.10.11)             |
 
 ## Rate Control Options
 

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -1087,6 +1087,21 @@ typedef struct EbSvtAv1EncConfiguration {
      */
     Bool low_q_taper;
 
+    /**
+     * @brief Limit the chroma distortion prediction from dropping too low in full mode decision
+     * Min value is 0.
+     * Max value is 1.
+     * Default is 0.
+     */
+    uint8_t chroma_distortion_taper;
+
+    /**
+     * @brief Completely disable skip mode and skip (as defined in section 6.10.10 and 6.10.11)
+     * Min value is 0.
+     * Max value is 1.
+     * Default is 0.
+     */
+    uint8_t skip_taper;
 
     /**
      * @brief Enable sharp-tx, a toggle that enables much sharper transforms decisions for higher fidelity ouput,
@@ -1165,7 +1180,7 @@ typedef struct EbSvtAv1EncConfiguration {
     Bool alt_tf_decay;
 
     /*Add 128 Byte Padding to Struct to avoid changing the size of the public configuration struct*/
-    uint8_t padding[128 - 9 * sizeof(Bool) - 14 * sizeof(uint8_t) - sizeof(int8_t) - 2 * sizeof(uint32_t) - 2 * sizeof(double)];
+    uint8_t padding[128 - 9 * sizeof(Bool) - 16 * sizeof(uint8_t) - sizeof(int8_t) - 2 * sizeof(uint32_t) - 2 * sizeof(double)];
 
 } EbSvtAv1EncConfiguration;
 

--- a/Source/App/app_config.c
+++ b/Source/App/app_config.c
@@ -226,6 +226,8 @@
 #define PSY_RD_TOKEN "--psy-rd"
 #define SPY_RD_TOKEN "--spy-rd"
 #define LOW_Q_TAPER_TOKEN "--low-q-taper"
+#define CHROMA_DISTORTION_TAPER_TOKEN "--chroma-distortion-taper"
+#define SKIP_TAPER_TOKEN "--skip-taper"
 #define SHARP_TX_TOKEN "--sharp-tx"
 #define HBD_MDS_TOKEN "--hbd-mds"
 #define COMPLEX_HVS_TOKEN "--complex-hvs"
@@ -1349,6 +1351,14 @@ ConfigEntry config_entry_psy[] = {
      "Low q taper. If macroblocks are boosted below q11, taper the effect. Default is 0 (off).",
      set_cfg_generic_token},
     {SINGLE_INPUT,
+     CHROMA_DISTORTION_TAPER_TOKEN,
+     "[PSY] Chroma distortion taper, default is 0 [0-1]",
+     set_cfg_generic_token},
+    {SINGLE_INPUT,
+     SKIP_TAPER_TOKEN,
+     "[PSY] Skip taper, default is 0 [0-1]",
+     set_cfg_generic_token},
+    {SINGLE_INPUT,
      SHARP_TX_TOKEN,
      "[PSY] Sharp transform optimization, default is 1; best used in combination with psy-rd [0-1]",
      set_cfg_generic_token},
@@ -1609,6 +1619,12 @@ ConfigEntry config_entry[] = {
 	
 	// Low q taper
     {SINGLE_INPUT, LOW_Q_TAPER_TOKEN, "LowQTaper", set_cfg_generic_token},
+
+    // Chroma Distortion Taper
+    {SINGLE_INPUT, CHROMA_DISTORTION_TAPER_TOKEN, "ChromaDistortionTaper", set_cfg_generic_token},
+
+    // Skip Taper
+    {SINGLE_INPUT, SKIP_TAPER_TOKEN, "SkipTaper", set_cfg_generic_token},
 
     // Sharp TX
     {SINGLE_INPUT, SHARP_TX_TOKEN, "SharpTX", set_cfg_generic_token},

--- a/Source/Lib/Codec/coding_loop.c
+++ b/Source/Lib/Codec/coding_loop.c
@@ -1191,6 +1191,9 @@ static void perform_intra_coding_loop(PictureControlSet *pcs, SuperBlock *sb_ptr
     } // Transform Loop
     assert(IMPLIES(!ed_ctx->blk_geom->has_uv, blk_ptr->u_has_coeff == 0 && blk_ptr->v_has_coeff == 0));
     blk_ptr->block_has_coeff = (blk_ptr->y_has_coeff || blk_ptr->u_has_coeff || blk_ptr->v_has_coeff);
+    if (pcs->scs->static_config.skip_taper) {
+        blk_ptr->block_has_coeff = TRUE;
+    }
 }
 #define REFMVS_LIMIT ((1 << 12) - 1)
 
@@ -1534,6 +1537,9 @@ static void perform_inter_coding_loop(SequenceControlSet *scs, PictureControlSet
 
     assert(IMPLIES(!blk_geom->has_uv, blk_ptr->u_has_coeff == 0 && blk_ptr->v_has_coeff == 0));
     blk_ptr->block_has_coeff = (blk_ptr->y_has_coeff || blk_ptr->u_has_coeff || blk_ptr->v_has_coeff);
+    if (pcs->scs->static_config.skip_taper) {
+        blk_ptr->block_has_coeff = TRUE;
+    }
 }
 
 /*

--- a/Source/Lib/Codec/product_coding_loop.c
+++ b/Source/Lib/Codec/product_coding_loop.c
@@ -6411,6 +6411,9 @@ static void full_loop_core_light_pd1(PictureControlSet *pcs, ModeDecisionContext
     }
     // Update coeff info based on luma TX so that chroma can take advantage of most accurate info
     cand_bf->block_has_coeff        = (cand_bf->y_has_coeff) ? 1 : 0;
+    if (pcs->scs->static_config.skip_taper) {
+        cand_bf->block_has_coeff = TRUE;
+    }
     cand_bf->cnt_nz_coeff           = cand_bf->eob.y[0];
     uint8_t        perform_chroma   = cand_bf->block_has_coeff || !(ctx->lpd1_tx_ctrls.zero_y_coeff_exit);
     COMPONENT_TYPE chroma_component = COMPONENT_CHROMA;
@@ -6474,6 +6477,9 @@ static void full_loop_core_light_pd1(PictureControlSet *pcs, ModeDecisionContext
                                            &cr_coeff_bits);
         cand_bf->block_has_coeff = (cand_bf->y_has_coeff || cand_bf->u_has_coeff || cand_bf->v_has_coeff) ? TRUE
                                                                                                           : FALSE;
+        if (pcs->scs->static_config.skip_taper) {
+            cand_bf->block_has_coeff = TRUE;
+        }
         svt_aom_full_cost(pcs,
                           ctx,
                           cand_bf,
@@ -6758,6 +6764,9 @@ static void full_loop_core(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
             cand_bf, ctx, pcs, start_tx_depth, end_tx_depth, ctx->blk_ptr->qindex, &y_coeff_bits, y_full_distortion);
     // Update coeff info based on luma TX so that chroma can take advantage of most accurate info
     cand_bf->block_has_coeff = (cand_bf->y_has_coeff) ? 1 : 0;
+    if (pcs->scs->static_config.skip_taper) {
+        cand_bf->block_has_coeff = TRUE;
+    }
 
     uint16_t txb_count    = ctx->blk_geom->txb_count[cand_bf->cand->tx_depth];
     cand_bf->cnt_nz_coeff = 0;
@@ -6864,6 +6873,9 @@ static void full_loop_core(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
         }
     }
     cand_bf->block_has_coeff = (cand_bf->y_has_coeff || cand_bf->u_has_coeff || cand_bf->v_has_coeff) ? TRUE : FALSE;
+    if (pcs->scs->static_config.skip_taper) {
+        cand_bf->block_has_coeff = TRUE;
+    }
     svt_aom_full_cost(pcs,
                       ctx,
                       cand_bf,

--- a/Source/Lib/Globals/enc_handle.c
+++ b/Source/Lib/Globals/enc_handle.c
@@ -5071,6 +5071,12 @@ static void copy_api_from_app(
     // Low Q taper
     scs->static_config.low_q_taper = config_struct->low_q_taper;
 
+    // Chroma distortion taper
+    scs->static_config.chroma_distortion_taper = config_struct->chroma_distortion_taper;
+
+    // Skip taper
+    scs->static_config.skip_taper = config_struct->skip_taper;
+
     // Sharp TX
     scs->static_config.sharp_tx = config_struct->sharp_tx;
 

--- a/Source/Lib/Globals/enc_settings.c
+++ b/Source/Lib/Globals/enc_settings.c
@@ -965,6 +965,16 @@ EbErrorType svt_av1_verify_settings(SequenceControlSet *scs) {
     //     return_error = EB_ErrorBadParameter;
     // }
 
+    if (config->chroma_distortion_taper > 1) {
+        SVT_ERROR("Instance %u: chroma-distortion-taper must be between 0 and 1\n", channel_number + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
+    if (config->skip_taper > 1) {
+        SVT_ERROR("Instance %u: skip-taper must be between 0 and 1\n", channel_number + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
     if (config->sharp_tx > 1) {
         SVT_ERROR("Instance %u: sharp-tx must be between 0 and 1\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
@@ -1156,6 +1166,8 @@ EbErrorType svt_av1_set_default_params(EbSvtAv1EncConfiguration *config_ptr) {
     config_ptr->psy_rd                            = 0.5;
     config_ptr->spy_rd                            = 0;
     config_ptr->low_q_taper                       = 0;
+    config_ptr->chroma_distortion_taper           = 0;
+    config_ptr->skip_taper                        = 0;
     config_ptr->sharp_tx                          = 1;
     config_ptr->hbd_mds                           = 0;
     config_ptr->complex_hvs                       = 0;
@@ -1386,6 +1398,14 @@ void svt_av1_print_lib_params(SequenceControlSet *scs) {
 		if (config->low_q_taper) {
             SVT_INFO("SVT [config]: low Q taper \t\t\t\t\t\t\t: %s\n",
                     config->low_q_taper ? "on" : "off");
+        }
+        
+		if (config->chroma_distortion_taper) {
+            SVT_INFO("SVT [config]: chroma distortion taper \t\t\t\t\t: on\n");
+        }
+        
+		if (config->skip_taper) {
+            SVT_INFO("SVT [config]: skip taper \t\t\t\t\t\t\t: on\n");
         }
         
         switch (config->filtering_noise_detection) {
@@ -2307,6 +2327,8 @@ EB_API EbErrorType svt_av1_enc_parse_parameter(EbSvtAv1EncConfiguration *config_
         {"tf-strength", &config_struct->tf_strength},
         {"kf-tf-strength", &config_struct->kf_tf_strength},
         {"noise-norm-strength", &config_struct->noise_norm_strength},
+        {"chroma-distortion-taper", &config_struct->chroma_distortion_taper},
+        {"skip-taper", &config_struct->skip_taper},
         {"fast-decode", &config_struct->fast_decode},
         {"enable-tf", &config_struct->enable_tf},
         {"spy-rd", &config_struct->spy_rd},


### PR DESCRIPTION
* `--chroma-distortion-taper` tapers a limit on the encoder's chroma distortion prediction in full mode decision. It gives a much better chroma with little to no downsides.  
  It only has effects in normal encoding `--preset`s such as `--preset 4` or slower because fast probing `--preset` such as `--preset 7` doesn't perform chroma distortion prediction at all.  
* `--skip-taper` is a very aggressive taper to completely disable skip mode and skip.  
   The pro is that it can completely prevent the issue of lineart disappearing or duplication (ghosting from its reference) in skipped blocks. The con is that it's very inefficient. The following comp is normalised to the same filesize via `--crf`, and you can see more blurriness and artefacts caused by insufficient bitrate in the image with `--skip-taper 1` compared to the other two images.  
  However, the situation is that without this taper you just can't prevent lineart disappearing or duplication no matter how low `--crf` you go. Depending on your situation it might be worth it.  
  That said, the ideal solution would certainly be to properly improve skip decision rather than just forcefully disable it, but before that happens this taper can help.  

comp: https://discord.com/channels/992019264959676448/1108801995088859257/1440591326616748044