### PR TITLE
`--skip-taper 2`

### DIFF
--- a/Docs/Parameters.md
+++ b/Docs/Parameters.md
@@ -88,7 +88,7 @@ For more information on valid values for specific keys, refer to the [EbEncSetti
 | **KeyframeTemporalFilteringStrength** |  --kf-tf-strength      | [0-4]                          | 1           | Manually adjust temporal filtering strength for keyframes. Higher values = stronger temporal filtering        |
 | **NoiseNormStrength**            |  --noise-norm-strength      | [0-4]                          | 1           | Selectively boost AC coefficients to improve fine detail retention in certain circumstances                   |
 | **ChromaDistortionTaper**        |  --chroma-distortion-taper  | [0-1]                          | 0           | Limit the chroma distortion prediction from dropping too low in full mode decision             |
-| **SkipTaper**                    |  --skip-taper               | [0-1]                          | 0           | Completely disable skip mode and skip (as defined in section 6.10.10 and 6.10.11)             |
+| **SkipTaper**                    |  --skip-taper               | [0-2]                          | 0           | Disable skip mode and skip (as defined in section 6.10.10 and 6.10.11) [1: completely disable skip mode and skip, 2: disable cost-based skip mode and skip selection] |
 
 ## Rate Control Options
 

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -1089,16 +1089,17 @@ typedef struct EbSvtAv1EncConfiguration {
 
     /**
      * @brief Limit the chroma distortion prediction from dropping too low in full mode decision
-     * Min value is 0.
-     * Max value is 1.
+     * 0: off
+     * 1: on
      * Default is 0.
      */
     uint8_t chroma_distortion_taper;
 
     /**
-     * @brief Completely disable skip mode and skip (as defined in section 6.10.10 and 6.10.11)
-     * Min value is 0.
-     * Max value is 1.
+     * @brief Disable skip mode and skip (as defined in section 6.10.10 and 6.10.11)
+     * 0: off
+     * 1: completely disable skip mode and skip
+     * 2: disable cost-based skip mode and skip selection
      * Default is 0.
      */
     uint8_t skip_taper;

--- a/Source/App/app_config.c
+++ b/Source/App/app_config.c
@@ -1356,7 +1356,7 @@ ConfigEntry config_entry_psy[] = {
      set_cfg_generic_token},
     {SINGLE_INPUT,
      SKIP_TAPER_TOKEN,
-     "[PSY] Skip taper, default is 0 [0-1]",
+     "[PSY] Skip taper, default is 0 [0-2]; 1 = completely disable skip mode and skip, 2 = disable cost-based skip mode and skip selection",
      set_cfg_generic_token},
     {SINGLE_INPUT,
      SHARP_TX_TOKEN,

--- a/Source/Lib/Codec/coding_loop.c
+++ b/Source/Lib/Codec/coding_loop.c
@@ -1191,9 +1191,8 @@ static void perform_intra_coding_loop(PictureControlSet *pcs, SuperBlock *sb_ptr
     } // Transform Loop
     assert(IMPLIES(!ed_ctx->blk_geom->has_uv, blk_ptr->u_has_coeff == 0 && blk_ptr->v_has_coeff == 0));
     blk_ptr->block_has_coeff = (blk_ptr->y_has_coeff || blk_ptr->u_has_coeff || blk_ptr->v_has_coeff);
-    if (pcs->scs->static_config.skip_taper) {
+    if (pcs->scs->static_config.skip_taper == 1)
         blk_ptr->block_has_coeff = TRUE;
-    }
 }
 #define REFMVS_LIMIT ((1 << 12) - 1)
 
@@ -1537,9 +1536,8 @@ static void perform_inter_coding_loop(SequenceControlSet *scs, PictureControlSet
 
     assert(IMPLIES(!blk_geom->has_uv, blk_ptr->u_has_coeff == 0 && blk_ptr->v_has_coeff == 0));
     blk_ptr->block_has_coeff = (blk_ptr->y_has_coeff || blk_ptr->u_has_coeff || blk_ptr->v_has_coeff);
-    if (pcs->scs->static_config.skip_taper) {
+    if (pcs->scs->static_config.skip_taper == 1)
         blk_ptr->block_has_coeff = TRUE;
-    }
 }
 
 /*

--- a/Source/Lib/Codec/product_coding_loop.c
+++ b/Source/Lib/Codec/product_coding_loop.c
@@ -6411,9 +6411,8 @@ static void full_loop_core_light_pd1(PictureControlSet *pcs, ModeDecisionContext
     }
     // Update coeff info based on luma TX so that chroma can take advantage of most accurate info
     cand_bf->block_has_coeff        = (cand_bf->y_has_coeff) ? 1 : 0;
-    if (pcs->scs->static_config.skip_taper) {
+    if (pcs->scs->static_config.skip_taper == 1)
         cand_bf->block_has_coeff = TRUE;
-    }
     cand_bf->cnt_nz_coeff           = cand_bf->eob.y[0];
     uint8_t        perform_chroma   = cand_bf->block_has_coeff || !(ctx->lpd1_tx_ctrls.zero_y_coeff_exit);
     COMPONENT_TYPE chroma_component = COMPONENT_CHROMA;
@@ -6477,9 +6476,8 @@ static void full_loop_core_light_pd1(PictureControlSet *pcs, ModeDecisionContext
                                            &cr_coeff_bits);
         cand_bf->block_has_coeff = (cand_bf->y_has_coeff || cand_bf->u_has_coeff || cand_bf->v_has_coeff) ? TRUE
                                                                                                           : FALSE;
-        if (pcs->scs->static_config.skip_taper) {
+        if (pcs->scs->static_config.skip_taper == 1)
             cand_bf->block_has_coeff = TRUE;
-        }
         svt_aom_full_cost(pcs,
                           ctx,
                           cand_bf,
@@ -6764,9 +6762,8 @@ static void full_loop_core(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
             cand_bf, ctx, pcs, start_tx_depth, end_tx_depth, ctx->blk_ptr->qindex, &y_coeff_bits, y_full_distortion);
     // Update coeff info based on luma TX so that chroma can take advantage of most accurate info
     cand_bf->block_has_coeff = (cand_bf->y_has_coeff) ? 1 : 0;
-    if (pcs->scs->static_config.skip_taper) {
+    if (pcs->scs->static_config.skip_taper == 1)
         cand_bf->block_has_coeff = TRUE;
-    }
 
     uint16_t txb_count    = ctx->blk_geom->txb_count[cand_bf->cand->tx_depth];
     cand_bf->cnt_nz_coeff = 0;
@@ -6873,9 +6870,8 @@ static void full_loop_core(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
         }
     }
     cand_bf->block_has_coeff = (cand_bf->y_has_coeff || cand_bf->u_has_coeff || cand_bf->v_has_coeff) ? TRUE : FALSE;
-    if (pcs->scs->static_config.skip_taper) {
+    if (pcs->scs->static_config.skip_taper == 1)
         cand_bf->block_has_coeff = TRUE;
-    }
     svt_aom_full_cost(pcs,
                       ctx,
                       cand_bf,

--- a/Source/Lib/Codec/rd_cost.c
+++ b/Source/Lib/Codec/rd_cost.c
@@ -1555,6 +1555,10 @@ void svt_aom_full_cost(PictureControlSet *pcs, ModeDecisionContext *ctx, struct 
                 ((uint64_t)ctx->md_rate_est_ctx->skip_fac_bits[skip_coeff_ctx][1]) + skip_tx_size_bits,
                 (y_distortion[DIST_SSD][1] + cb_distortion[DIST_SSD][1] + cr_distortion[DIST_SSD][1]));
         } else {
+            // The use of qstep table here is completely arbitrary. It needs
+            // something in the range of a few hundred to a few thousand, and it
+            // needs something that corresponds with quality, and the qstep table
+            // just happenes to fit both of these two points.
             non_skip_cost = RDCOST(
                 lambda,
                 (*y_coeff_bits + *cb_coeff_bits + *cr_coeff_bits + non_skip_tx_size_bits +
@@ -1616,10 +1620,6 @@ void svt_aom_full_cost(PictureControlSet *pcs, ModeDecisionContext *ctx, struct 
             ? y_distortion[DIST_SSIM][0] + cb_distortion[DIST_SSIM][0] + cr_distortion[DIST_SSIM][0]
             : 0;
     } else {
-        // The use of qstep table here is completely arbitrary. It needs
-        // something in the range of a few hundred to a few thousand, and it
-        // needs something that corresponds with quality, and the qstep table
-        // just happenes to fit both of these two points.
         mode_distortion      = y_distortion[DIST_SSD][0] +
             AOMMAX(cb_distortion[DIST_SSD][0] + cr_distortion[DIST_SSD][0],
                    (uint64_t)(1.5 * svt_aom_dc_quant_qtx(quantizer_to_qindex[(uint8_t)pcs->scs->static_config.qp] + pcs->scs->static_config.extended_crf_qindex_offset,

--- a/Source/Lib/Globals/enc_settings.c
+++ b/Source/Lib/Globals/enc_settings.c
@@ -970,8 +970,8 @@ EbErrorType svt_av1_verify_settings(SequenceControlSet *scs) {
         return_error = EB_ErrorBadParameter;
     }
 
-    if (config->skip_taper > 1) {
-        SVT_ERROR("Instance %u: skip-taper must be between 0 and 1\n", channel_number + 1);
+    if (config->skip_taper > 2) {
+        SVT_ERROR("Instance %u: skip-taper must be between 0 and 2\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }
 
@@ -1405,7 +1405,8 @@ void svt_av1_print_lib_params(SequenceControlSet *scs) {
         }
         
 		if (config->skip_taper) {
-            SVT_INFO("SVT [config]: skip taper \t\t\t\t\t\t\t: on\n");
+            SVT_INFO("SVT [config]: skip taper \t\t\t\t\t\t\t: %s\n",
+                     config->skip_taper == 1 ? "full" : "cost taper");
         }
         
         switch (config->filtering_noise_detection) {


### PR DESCRIPTION
I'm sorry for the separate pull request. Every time I think I'm done... and then a day later I would have new ideas......  

* `--skip-taper 2` only disables cost-based skip mode and skip selection. The filesize increase in this mode should be fairly moderate which makes it much more applicable in especially lower quality levels. Although it doesn't deliver the [completely getting rid of skip related issues] effect of `--skip-taper 1`, it still looks to be helpful.  

Just found something unexpected. Give me a second.
Thank you!  