### PR TITLE
fix: `extended_crf_qindex_offset` added twice to `chroma_qindex`

### DIFF
--- a/Source/Lib/Codec/rc_process.c
+++ b/Source/Lib/Codec/rc_process.c
@@ -3480,7 +3480,7 @@ void *svt_aom_rate_control_kernel(void *input_ptr) {
                         chroma_qindex -= CLIP3(0, 16, (chroma_qindex_adjustment / 2) - 8);
                     }
 
-                    chroma_qindex += scs->static_config.extended_crf_qindex_offset;
+                    // chroma_qindex += scs->static_config.extended_crf_qindex_offset;
                     chroma_qindex = CLIP3(quantizer_to_qindex[scs->static_config.min_qp_allowed],
                                           quantizer_to_qindex[scs->static_config.max_qp_allowed],
                                           chroma_qindex);


### PR DESCRIPTION
So `scs->static_config.extended_crf_qindex_offset` is added to `scs_qindex` here
https://github.com/5fish/svt-av1-psy/blob/137368e6580bc5b588659745e32684fb3e4fb247/Source/Lib/Codec/rc_process.c#L3409-L3411

Which becomes `rc->active_worst_quality` here
https://github.com/5fish/svt-av1-psy/blob/137368e6580bc5b588659745e32684fb3e4fb247/Source/Lib/Codec/rc_process.c#L3433

Which becomes `new_qindex` here
https://github.com/5fish/svt-av1-psy/blob/137368e6580bc5b588659745e32684fb3e4fb247/Source/Lib/Codec/rc_process.c#L3437-L3439

Which becomes `quantization_params.base_q_idx` here
https://github.com/5fish/svt-av1-psy/blob/137368e6580bc5b588659745e32684fb3e4fb247/Source/Lib/Codec/rc_process.c#L3445-L3448

And `chroma_qindex` is taken from `quantization_params.base_q_idx` here
https://github.com/5fish/svt-av1-psy/blob/137368e6580bc5b588659745e32684fb3e4fb247/Source/Lib/Codec/rc_process.c#L3483

And `scs->static_config.extended_crf_qindex_offset` is added a second time to `chroma_qindex` here
https://github.com/5fish/svt-av1-psy/blob/137368e6580bc5b588659745e32684fb3e4fb247/Source/Lib/Codec/rc_process.c#L3516

Not sure if I misread something.... Thank you as always, 5fish!  