### PR TITLE
Do not inline svt_aom_enc_make_inter_predictor()

### DIFF
--- a/Source/Lib/Codec/enc_inter_prediction.c
+++ b/Source/Lib/Codec/enc_inter_prediction.c
@@ -3276,14 +3276,14 @@ static void enc_make_inter_predictor_light_pd0(uint8_t *src, uint8_t *dst, Subpe
                                                int32_t src_stride, int32_t dst_stride) {
     svt_inter_predictor_light_pd0(src, src_stride, dst, dst_stride, blk_width, blk_height, subpel_params, conv_params);
 }
-void svt_aom_enc_make_inter_predictor(SequenceControlSet *scs, uint8_t *src_ptr, uint8_t *src_ptr_2b, uint8_t *dst_ptr,
-                                      int16_t pre_y, int16_t pre_x, MV mv, const struct ScaleFactors *const sf,
-                                      ConvolveParams *conv_params, InterpFilters interp_filters,
-                                      InterInterCompoundData *interinter_comp, uint8_t *seg_mask, uint16_t frame_width,
-                                      uint16_t frame_height, uint8_t blk_width, uint8_t blk_height, BlockSize bsize,
-                                      MacroBlockD *av1xd, int32_t src_stride, int32_t dst_stride, uint8_t plane,
-                                      const uint32_t ss_y, const uint32_t ss_x, uint8_t bit_depth, uint8_t use_intrabc,
-                                      uint8_t is_masked_compound, uint8_t is16bit) {
+void NOINLINE svt_aom_enc_make_inter_predictor(SequenceControlSet *scs, uint8_t *src_ptr, uint8_t *src_ptr_2b, uint8_t *dst_ptr,
+                                               int16_t pre_y, int16_t pre_x, MV mv, const struct ScaleFactors *const sf,
+                                               ConvolveParams *conv_params, InterpFilters interp_filters,
+                                               InterInterCompoundData *interinter_comp, uint8_t *seg_mask, uint16_t frame_width,
+                                               uint16_t frame_height, uint8_t blk_width, uint8_t blk_height, BlockSize bsize,
+                                               MacroBlockD *av1xd, int32_t src_stride, int32_t dst_stride, uint8_t plane,
+                                               const uint32_t ss_y, const uint32_t ss_x, uint8_t bit_depth, uint8_t use_intrabc,
+                                               uint8_t is_masked_compound, uint8_t is16bit) {
     SubpelParams subpel_params;
     int32_t      pos_y, pos_x;
 


### PR DESCRIPTION
Maybe we should wait and see if there are other fixes incoming before SVT-AV1-HDR is officially released.  

Thank you as always, 5fish!  